### PR TITLE
Fix to undefined error on invalid change

### DIFF
--- a/src/components/StripeCard.component.ts
+++ b/src/components/StripeCard.component.ts
@@ -20,7 +20,7 @@ import { string as template } from "./templates/stripe-card.pug"
 
   stripe:StripeInstance
   elements:any
-  
+
   constructor(
     public ElementRef:ElementRef,
     public StripeScriptTag:StripeScriptTag
@@ -30,11 +30,11 @@ import { string as template } from "./templates/stripe-card.pug"
     this.StripeScriptTag.promiseInstance()
     .then(i=>{
       this.stripe = i
-      
+
       this.elements = this.stripe.elements().create('card', this.options)
       this.elements.mount(this.ElementRef.nativeElement)
 
-      this.elements.addEventListener('change', function(result) {
+      this.elements.addEventListener('change', result=>{
         if( result.error ){
           this.invalidChange.emit( this.invalid=result.error )
         }


### PR DESCRIPTION
When an invalid change event is emitted an error appears in console log:

<img width="686" alt="screenshot 2019-02-13 at 00 35 20" src="https://user-images.githubusercontent.com/20923472/52677817-505ccd80-2f27-11e9-9978-1cd454d963e0.png">

This fix changes: (line 30 - 34 in `dist/components/StripeCard.component.js`)
```
_this.elements.addEventListener('change', function (result) {
    if (result.error) {
        this.invalidChange.emit(this.invalid = result.error);
    }
});
```

To this:
```
_this.elements.addEventListener('change', function (result) {
    if (result.error) {
        _this.invalidChange.emit(_this.invalid = result.error);
    }
});
```