### PR TITLE
 Install stripe-angular as a main dependency instead of dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Angular to Stripe module containing useful providers, components, and directives
 ## Install
 From a command terminal type the following
 ```
-npm install stripe-angular --save-dev
+npm install stripe-angular --save
 ```
 
 ## Inject


### PR DESCRIPTION
Change instruction to install stripe-angular as a main dependency instead of a dev dependency.