### PR TITLE
Fix ngcc

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "10.9"
+    - nodejs_version: "10.13"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-angular",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Angular to Stripe module containing useful providers, components, and directives",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const declarations = [
 }) export class StripeModule {
   static forRoot(publishableKey?: string, options?: StripeInstanceOptions): ModuleWithProviders {
     return {
-      ngModule: Module,
+      ngModule: StripeModule,
       providers: [
         StripeScriptTag,
         {


### PR DESCRIPTION
Fixes #25 

Looks like I missed a reference to `Module`

Ran `npm run build` then copied the output `dist` into `node_modules/stripe_angular` of my local project then ran `ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points`, no errors occurred.

Issue seems to be resolved with this change.