### PR TITLE
Fix typedef on StripeModule for Angular 10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-angular",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Angular to Stripe module containing useful providers, components, and directives",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ const declarations = [
  // providers: [ StripeScriptTag ],
   exports:[ ...declarations ]
 }) export class StripeModule {
-  static forRoot(publishableKey?: string, options?: StripeInstanceOptions): ModuleWithProviders {
+  static forRoot(publishableKey?: string, options?: StripeInstanceOptions): ModuleWithProviders<StripeModule> {
     return {
       ngModule: StripeModule,
       providers: [


### PR DESCRIPTION
As for Angular 10+, it is now required to type cast `ModuleWithProviders<T>` on `StripeModule.forRoot()` as it is mentioned on their [documentation](https://angular.io/guide/migration-module-with-providers), otherwise, the Angular compiler will complain about it and block the project build.